### PR TITLE
Feat: return additional error object with exception

### DIFF
--- a/src/Pay/Adapter/Stripe.php
+++ b/src/Pay/Adapter/Stripe.php
@@ -359,7 +359,7 @@ class Stripe extends Adapter
                 $type = $error['decline_code'] ?? $type;
             }
             $message = $error['message'] ?? 'Unknown error';
-            throw new Exception($type, $message, $code);
+            throw new Exception($type, $message, $code, $error);
         }
 
         throw new Exception($response, $code);

--- a/src/Pay/Exception.php
+++ b/src/Pay/Exception.php
@@ -16,10 +16,18 @@ class Exception extends \Exception
 
     protected string $type = '';
 
-    public function __construct(string $type = Exception::GENERAL_UNKNOWN, string $message = null, int $code = null, \Throwable $previous = null)
+    /**
+     * Error object with additional error data
+     *
+     * @var array
+     */
+    protected array $error = [];
+
+    public function __construct(string $type = Exception::GENERAL_UNKNOWN, string $message = null, int $code = null, array $error = [], \Throwable $previous = null)
     {
         $this->type = $type;
         $this->code = $code ?? 500;
+        $this->error = $error;
 
         $this->message = $message ?? 'Unknown error';
 

--- a/src/Pay/Exception.php
+++ b/src/Pay/Exception.php
@@ -17,17 +17,17 @@ class Exception extends \Exception
     protected string $type = '';
 
     /**
-     * Error object with additional error data
+     * Metadata object with additional error data
      *
      * @var array
      */
-    protected array $error = [];
+    protected array $metadata = [];
 
-    public function __construct(string $type = Exception::GENERAL_UNKNOWN, string $message = null, int $code = null, array $error = [], \Throwable $previous = null)
+    public function __construct(string $type = Exception::GENERAL_UNKNOWN, string $message = null, int $code = null, array $metadata = [], \Throwable $previous = null)
     {
         $this->type = $type;
         $this->code = $code ?? 500;
-        $this->error = $error;
+        $this->metadata = $metadata;
 
         $this->message = $message ?? 'Unknown error';
 
@@ -56,23 +56,23 @@ class Exception extends \Exception
     }
 
     /**
-     * Get error object.
+     * Get metadata object.
      *
      * @return string
      */
-    public function getError(): array
+    public function getMetadata(): array
     {
-        return $this->error;
+        return $this->metadata;
     }
 
     /**
-     * Set error object.
+     * Set metadata object.
      *
-     * @param  array  $error
+     * @param  array  $metadata
      * @return void
      */
-    public function setError(array $error): void
+    public function setMetadata(array $metadata): void
     {
-        $this->error = $error;
+        $this->metadata = $metadata;
     }
 }

--- a/src/Pay/Exception.php
+++ b/src/Pay/Exception.php
@@ -54,4 +54,25 @@ class Exception extends \Exception
     {
         $this->type = $type;
     }
+
+    /**
+     * Get error object.
+     *
+     * @return string
+     */
+    public function getError(): array
+    {
+        return $this->error;
+    }
+
+    /**
+     * Set error object.
+     *
+     * @param  array  $error
+     * @return void
+     */
+    public function setError(array $error): void
+    {
+        $this->error = $error;
+    }
 }

--- a/tests/Pay/Adapter/StripeTest.php
+++ b/tests/Pay/Adapter/StripeTest.php
@@ -408,8 +408,8 @@ class StripeTest extends TestCase
         } catch (Exception $e) {
             $this->assertEquals(402, $e->getCode());
             $this->assertEquals(Exception::AUTHENTICATION_REQUIRED, $e->getType());
-            $this->assertNotEmpty($e->getError());
-            $this->assertEquals(Exception::AUTHENTICATION_REQUIRED, $e->getError()['decline_code']);
+            $this->assertNotEmpty($e->getMetadata());
+            $this->assertEquals(Exception::AUTHENTICATION_REQUIRED, $e->getMetadata()['decline_code']);
             $this->assertInstanceOf(Exception::class, $e);
         }
 

--- a/tests/Pay/Adapter/StripeTest.php
+++ b/tests/Pay/Adapter/StripeTest.php
@@ -408,6 +408,8 @@ class StripeTest extends TestCase
         } catch (Exception $e) {
             $this->assertEquals(402, $e->getCode());
             $this->assertEquals(Exception::AUTHENTICATION_REQUIRED, $e->getType());
+            $this->assertNotEmpty($e->getError());
+            $this->assertEquals(Exception::AUTHENTICATION_REQUIRED, $e->getError()['decline_code']);
             $this->assertInstanceOf(Exception::class, $e);
         }
 


### PR DESCRIPTION
- Returns additional error object in the execption
- This is required, for example, if the error is regarding payment requiring authentication, we need the details of the payment to be able to send authorization request to the user