### PR TITLE
Retry purchase to confirm the payment intent again

### DIFF
--- a/src/Pay/Adapter.php
+++ b/src/Pay/Adapter.php
@@ -81,6 +81,16 @@ abstract class Adapter
     abstract public function purchase(int $amount, string $customerId, ?string $paymentMethodId = null, array $additionalParams = []): array;
 
     /**
+     * Retry a purchase for a payment intent
+     *
+     * @param  string  $paymentId The payment intent ID to retry
+     * @param  string|null  $paymentMethodId The payment method to use (optional)
+     * @param  array<mixed>  $additionalParams Additional parameters for the retry (optional)
+     * @return array<mixed> The result of the retry attempt
+     */
+    abstract public function retryPurchase(string $paymentId, ?string $paymentMethodId = null, array $additionalParams = []): array;
+
+    /**
      * Refund payment
      *
      * @param  string  $paymentId

--- a/src/Pay/Adapter/Stripe.php
+++ b/src/Pay/Adapter/Stripe.php
@@ -48,6 +48,30 @@ class Stripe extends Adapter
     }
 
     /**
+     * Retry a purchase for a payment intent
+     *
+     * @param  string  $paymentId The payment intent ID to retry
+     * @param  string|null  $paymentMethodId The payment method to use (optional)
+     * @param  array<mixed>  $additionalParams Additional parameters for the retry (optional)
+     * @return array<mixed> The result of the retry attempt
+     */
+    public function retryPurchase(string $paymentId, ?string $paymentMethodId = null, array $additionalParams = []): array
+    {
+        $path = '/payment_intents/'.$paymentId.'/confirm';
+        $requestBody = [];
+        if (! empty($paymentMethodId)) {
+            $requestBody = [
+                'payment_method' => $paymentMethodId,
+            ];
+        }
+
+        $requestBody = array_merge($requestBody, $additionalParams);
+        $result = $this->execute(self::METHOD_POST, $path, $requestBody);
+
+        return $result;
+    }
+
+    /**
      * Refund payment
      */
     public function refund(string $paymentId, int $amount = null, string $reason = null): array

--- a/src/Pay/Pay.php
+++ b/src/Pay/Pay.php
@@ -87,6 +87,19 @@ class Pay
     }
 
     /**
+     * Retry a purchase for a payment intent
+     *
+     * @param  string  $paymentId The payment intent ID to retry
+     * @param  string|null  $paymentMethodId The payment method to use (optional)
+     * @param  array<mixed>  $additionalParams Additional parameters for the retry (optional)
+     * @return array<mixed> The result of the retry attempt
+     */
+    public function retryPurchase(string $paymentId, ?string $paymentMethodId = null, array $additionalParams = []): array
+    {
+        return $this->adapter->retryPurchase($paymentId, $paymentMethodId, $additionalParams);
+    }
+
+    /**
      * Refund Payment
      *
      * @param  string  $paymentId

--- a/tests/Pay/Adapter/StripeTest.php
+++ b/tests/Pay/Adapter/StripeTest.php
@@ -294,6 +294,27 @@ class StripeTest extends TestCase
 
     /**
      * @depends testPurchase
+     *
+     * @param  array<mixed>  $data
+     * @return array<mixed>
+     */
+    public function testRetryPurchase(array $data): array
+    {
+        $paymentId = $data['paymentId'];
+        $paymentMethodId = $data['paymentMethodId'];
+        // Attempt to retry the purchase
+        $result = $this->stripe->retryPurchase($paymentId, $paymentMethodId);
+        $this->assertNotEmpty($result['id']);
+        $this->assertEquals($paymentId, $result['id']);
+        $this->assertEquals('payment_intent', $result['object']);
+        // Status may vary depending on Stripe's state, but should be present
+        $this->assertArrayHasKey('status', $result);
+
+        return $data;
+    }
+
+    /**
+     * @depends testPurchase
      */
     public function testGetPayment(array $data): array
     {

--- a/tests/Pay/Adapter/StripeTest.php
+++ b/tests/Pay/Adapter/StripeTest.php
@@ -316,27 +316,23 @@ class StripeTest extends TestCase
         // Create a payment intent with the failing payment method
         $paymentIntentId = null;
         try {
-            $purchase = $this->stripe->purchase(5000, $customerId, $failingPmId);
+            $this->stripe->purchase(5000, $customerId, $failingPmId);
             $this->fail('Expected payment to fail');
         } catch (Exception $e) {
             $this->assertEquals(Exception::GENERIC_DECLINE, $e->getType());
             $this->assertEquals(402, $e->getCode());
             $paymentIntentMeta = $e->getMetadata()['payment_intent'] ?? null;
-            if (is_array($paymentIntentMeta) && isset($paymentIntentMeta['id'])) {
-                $paymentIntentId = $paymentIntentMeta['id'];
-            } else {
-                $paymentIntentId = $paymentIntentMeta;
-            }
+            $paymentIntentId = is_array($paymentIntentMeta) && isset($paymentIntentMeta['id']) ? $paymentIntentMeta['id'] : $paymentIntentMeta;
             $this->assertNotEmpty($paymentIntentId);
         }
 
-        // Create a succeeding payment method
-        $succeedingPm = $this->stripe->createPaymentMethod($customerId, 'card', [
-            'number' => '4242424242424242', // Stripe test card: always succeeds
-            'exp_month' => 8,
-            'exp_year' => 2030,
-            'cvc' => 123,
-        ]);
+         // Create a succeeding payment method
+         $succeedingPm = $this->stripe->createPaymentMethod($customerId, 'card', [
+             'number' => '4242424242424242', // Stripe test card: always succeeds
+             'exp_month' => 8,
+             'exp_year' => 2030,
+             'cvc' => 123,
+         ]);
         $this->assertNotEmpty($succeedingPm['id']);
         $succeedingPmId = $succeedingPm['id'];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to retry a purchase for an existing payment intent using a new method.
* **Tests**
  * Introduced new tests to verify the retry purchase functionality, including handling failed and successful retry attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->