### PR TITLE
Feat: authorize and capture payment

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,88 @@ $purchase = $pay->purchase(
 var_dump($purchase);
 ```
 
+## Features
+
+### Direct Purchase
+Immediately charge a customer's payment method:
+
+```php
+$purchase = $pay->purchase(
+    5000,
+    $customerId,
+    $paymentMethodId
+);
+```
+
+### Authorization and Capture (Hold and Charge)
+For scenarios where you need to verify payment availability before providing a service (e.g., domain registration, ticket booking):
+
+```php
+// Step 1: Authorize payment (hold funds)
+$authorization = $pay->authorize(
+    5000,
+    $customerId,
+    $paymentMethodId,
+    [
+        'metadata' => [
+            'domain' => 'example.com',
+            'order_id' => 'ORD-12345'
+        ]
+    ]
+);
+
+// Step 2: Acquire resource from vendor
+try {
+    $domain = purchaseDomainFromVendor('example.com');
+    
+    // Step 3a: Capture payment on success
+    $captured = $pay->capture($authorization['id']);
+    
+} catch (Exception $e) {
+    // Step 3b: Cancel authorization on failure (release hold)
+    $cancelled = $pay->cancelAuthorization($authorization['id']);
+}
+```
+
+See the [Payment Authorization and Capture Guide](docs/tutorials/payment-authorization-capture.md) for detailed examples.
+
+### Customer Management
+```php
+// Create customer
+$customer = $pay->createCustomer('John Doe', 'john@example.com');
+
+// Get customer
+$customer = $pay->getCustomer($customerId);
+
+// Update customer
+$updated = $pay->updateCustomer($customerId, 'Jane Doe', 'jane@example.com');
+
+// Delete customer
+$pay->deleteCustomer($customerId);
+```
+
+### Payment Methods
+```php
+// Add payment method
+$paymentMethod = $pay->createPaymentMethod($customerId, 'card', [
+    'number' => '4242424242424242',
+    'exp_month' => 12,
+    'exp_year' => 2025,
+    'cvc' => '123'
+]);
+
+// List payment methods
+$methods = $pay->listPaymentMethods($customerId);
+
+// Delete payment method
+$pay->deletePaymentMethod($paymentMethodId);
+```
+
+### Refunds
+```php
+$refund = $pay->refund($paymentId, 3000); // Refund $30.00
+```
+
 ## System Requirements
 
 Utopia Pay requires PHP 8.0 or later. We recommend using the latest PHP version whenever possible.

--- a/src/Pay/Adapter.php
+++ b/src/Pay/Adapter.php
@@ -81,6 +81,39 @@ abstract class Adapter
     abstract public function purchase(int $amount, string $customerId, ?string $paymentMethodId = null, array $additionalParams = []): array;
 
     /**
+     * Authorize a payment (hold funds without capturing)
+     * Useful for scenarios where you need to ensure payment availability before providing service
+     *
+     * @param  int  $amount Amount to authorize
+     * @param  string  $customerId Customer ID
+     * @param  string|null  $paymentMethodId Payment method ID (optional)
+     * @param  array<mixed>  $additionalParams Additional parameters (optional)
+     * @return array<mixed> Result of the authorization including authorization ID
+     */
+    abstract public function authorize(int $amount, string $customerId, ?string $paymentMethodId = null, array $additionalParams = []): array;
+
+    /**
+     * Capture a previously authorized payment
+     * Completes the payment and transfers funds from customer
+     *
+     * @param  string  $paymentId The payment/authorization ID to capture
+     * @param  int|null  $amount Amount to capture (optional, defaults to full authorized amount)
+     * @param  array<mixed>  $additionalParams Additional parameters (optional)
+     * @return array<mixed> Result of the capture
+     */
+    abstract public function capture(string $paymentId, ?int $amount = null, array $additionalParams = []): array;
+
+    /**
+     * Cancel/void a payment authorization
+     * Releases the hold on funds without capturing
+     *
+     * @param  string  $paymentId The payment/authorization ID to cancel
+     * @param  array<mixed>  $additionalParams Additional parameters (optional)
+     * @return array<mixed> Result of the cancellation
+     */
+    abstract public function cancelAuthorization(string $paymentId, array $additionalParams = []): array;
+
+    /**
      * Update a payment intent
      *
      * @param  string  $paymentId Payment intent ID

--- a/src/Pay/Adapter/Stripe.php
+++ b/src/Pay/Adapter/Stripe.php
@@ -94,8 +94,7 @@ class Stripe extends Adapter
     public function cancelAuthorization(string $paymentId, array $additionalParams = []): array
     {
         $path = '/payment_intents/'.$paymentId.'/cancel';
-        $requestBody = array_merge([], $additionalParams);
-        $result = $this->execute(self::METHOD_POST, $path, $requestBody);
+        $result = $this->execute(self::METHOD_POST, $path, $additionalParams);
 
         return $result;
     }

--- a/src/Pay/Adapter/Stripe.php
+++ b/src/Pay/Adapter/Stripe.php
@@ -48,6 +48,59 @@ class Stripe extends Adapter
     }
 
     /**
+     * Authorize a payment (hold funds without capturing)
+     * Creates a payment intent with capture_method set to manual
+     */
+    public function authorize(int $amount, string $customerId, ?string $paymentMethodId = null, array $additionalParams = []): array
+    {
+        $path = '/payment_intents';
+        $requestBody = [
+            'amount' => $amount,
+            'currency' => $this->currency,
+            'customer' => $customerId,
+            'payment_method' => $paymentMethodId,
+            'capture_method' => 'manual',
+            'off_session' => 'true',
+            'confirm' => 'true',
+        ];
+
+        $requestBody = array_merge($requestBody, $additionalParams);
+        $result = $this->execute(self::METHOD_POST, $path, $requestBody);
+
+        return $result;
+    }
+
+    /**
+     * Capture a previously authorized payment
+     */
+    public function capture(string $paymentId, ?int $amount = null, array $additionalParams = []): array
+    {
+        $path = '/payment_intents/'.$paymentId.'/capture';
+        $requestBody = [];
+
+        if ($amount !== null) {
+            $requestBody['amount_to_capture'] = $amount;
+        }
+
+        $requestBody = array_merge($requestBody, $additionalParams);
+        $result = $this->execute(self::METHOD_POST, $path, $requestBody);
+
+        return $result;
+    }
+
+    /**
+     * Cancel/void a payment authorization
+     */
+    public function cancelAuthorization(string $paymentId, array $additionalParams = []): array
+    {
+        $path = '/payment_intents/'.$paymentId.'/cancel';
+        $requestBody = array_merge([], $additionalParams);
+        $result = $this->execute(self::METHOD_POST, $path, $requestBody);
+
+        return $result;
+    }
+
+    /**
      * Retry a purchase for a payment intent
      *
      * @param  string  $paymentId The payment intent ID to retry

--- a/src/Pay/Pay.php
+++ b/src/Pay/Pay.php
@@ -87,6 +87,52 @@ class Pay
     }
 
     /**
+     * Authorize
+     * Authorize a payment (hold funds without capturing)
+     * Useful for scenarios where you need to ensure payment availability before providing service
+     * Returns authorization ID on successful authorization
+     *
+     * @param  int  $amount
+     * @param  string  $customerId
+     * @param  string|null  $paymentMethodId
+     * @param  array<mixed>  $additionalParams
+     * @return array<mixed>
+     */
+    public function authorize(int $amount, string $customerId, string $paymentMethodId = null, array $additionalParams = []): array
+    {
+        return $this->adapter->authorize($amount, $customerId, $paymentMethodId, $additionalParams);
+    }
+
+    /**
+     * Capture
+     * Capture a previously authorized payment
+     * Completes the payment and transfers funds from customer
+     *
+     * @param  string  $paymentId
+     * @param  int|null  $amount
+     * @param  array<mixed>  $additionalParams
+     * @return array<mixed>
+     */
+    public function capture(string $paymentId, ?int $amount = null, array $additionalParams = []): array
+    {
+        return $this->adapter->capture($paymentId, $amount, $additionalParams);
+    }
+
+    /**
+     * Cancel Authorization
+     * Cancel/void a payment authorization
+     * Releases the hold on funds without capturing
+     *
+     * @param  string  $paymentId
+     * @param  array<mixed>  $additionalParams
+     * @return array<mixed>
+     */
+    public function cancelAuthorization(string $paymentId, array $additionalParams = []): array
+    {
+        return $this->adapter->cancelAuthorization($paymentId, $additionalParams);
+    }
+
+    /**
      * Retry a purchase for a payment intent
      *
      * @param  string  $paymentId The payment intent ID to retry


### PR DESCRIPTION
- Hold amount first and capture later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authorization and capture workflow enabling payment holds with subsequent charge or cancellation
  * Enabled partial capture for authorized payments
  * Added authorization cancellation capability

* **Documentation**
  * Enhanced README with examples for purchases, authorization/capture flows, customer management, payment methods, and refunds

* **Tests**
  * Added end-to-end tests covering authorize → capture → cancel flows and partial captures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->