### PR TITLE
Fix explicit nullable types for PHP 8.4+ deprecations

### DIFF
--- a/src/Pay/Adapter.php
+++ b/src/Pay/Adapter.php
@@ -123,7 +123,7 @@ abstract class Adapter
      * @param  array<mixed>  $additionalParams Additional parameters (optional)
      * @return array<mixed> Result of the update
      */
-    abstract public function updatePayment(string $paymentId, ?string $paymentMethodId = null, ?int $amount = null, string $currency = null, array $additionalParams = []): array;
+    abstract public function updatePayment(string $paymentId, ?string $paymentMethodId = null, ?int $amount = null, ?string $currency = null, array $additionalParams = []): array;
 
     /**
      * Retry a purchase for a payment intent
@@ -143,7 +143,7 @@ abstract class Adapter
      * @param  string  $reason
      * @return array<mixed>
      */
-    abstract public function refund(string $paymentId, int $amount = null, string $reason = null): array;
+    abstract public function refund(string $paymentId, ?int $amount = null, ?string $reason = null): array;
 
     /**
      * Get a payment details
@@ -173,7 +173,7 @@ abstract class Adapter
      * @param  array<mixed>|null  $address
      * @return array<mixed>
      */
-    abstract public function updatePaymentMethodBillingDetails(string $paymentMethodId, string $name = null, string $email = null, string $phone = null, array $address = null): array;
+    abstract public function updatePaymentMethodBillingDetails(string $paymentMethodId, ?string $name = null, ?string $email = null, ?string $phone = null, ?array $address = null): array;
 
     /**
      * Update payment method
@@ -210,7 +210,7 @@ abstract class Adapter
      * @param  string|null  $paymentMethod
      * @return array<mixed>
      */
-    abstract public function createCustomer(string $name, string $email, array $address = [], string $paymentMethod = null): array;
+    abstract public function createCustomer(string $name, string $email, array $address = [], ?string $paymentMethod = null): array;
 
     /**
      * List customers
@@ -237,7 +237,7 @@ abstract class Adapter
      * @param  string|null  $paymentMethod
      * @return array<mixed>
      */
-    abstract public function updateCustomer(string $customerId, string $name, string $email, Address $address = null, string $paymentMethod = null): array;
+    abstract public function updateCustomer(string $customerId, string $name, string $email, ?Address $address = null, ?string $paymentMethod = null): array;
 
     /**
      * Delete Customer

--- a/src/Pay/Adapter/Stripe.php
+++ b/src/Pay/Adapter/Stripe.php
@@ -126,7 +126,7 @@ class Stripe extends Adapter
     /**
      * Refund payment
      */
-    public function refund(string $paymentId, int $amount = null, string $reason = null): array
+    public function refund(string $paymentId, ?int $amount = null, ?string $reason = null): array
     {
         $path = '/refunds';
         $requestBody = ['payment_intent' => $paymentId];
@@ -164,7 +164,7 @@ class Stripe extends Adapter
      * @param  array<mixed>  $additionalParams Additional parameters (optional)
      * @return array<mixed> Result of the update
      */
-    public function updatePayment(string $paymentId, ?string $paymentMethodId = null, ?int $amount = null, string $currency = null, array $additionalParams = []): array
+    public function updatePayment(string $paymentId, ?string $paymentMethodId = null, ?int $amount = null, ?string $currency = null, array $additionalParams = []): array
     {
         $path = '/payment_intents/'.$paymentId;
         $requestBody = [];
@@ -236,7 +236,7 @@ class Stripe extends Adapter
      * @param  array<mixed>|null  $address
      * @return array<mixed>
      */
-    public function updatePaymentMethodBillingDetails(string $paymentMethodId, string $name = null, string $email = null, string $phone = null, array $address = null): array
+    public function updatePaymentMethodBillingDetails(string $paymentMethodId, ?string $name = null, ?string $email = null, ?string $phone = null, ?array $address = null): array
     {
         $path = '/payment_methods/'.$paymentMethodId;
         $requestBody = [];
@@ -285,7 +285,7 @@ class Stripe extends Adapter
      *
      * @throws \Exception
      */
-    public function createCustomer(string $name, string $email, array $address = [], string $paymentMethod = null): array
+    public function createCustomer(string $name, string $email, array $address = [], ?string $paymentMethod = null): array
     {
         $path = '/customers';
         $requestBody = [
@@ -325,7 +325,7 @@ class Stripe extends Adapter
     /**
      * Update customer details
      */
-    public function updateCustomer(string $customerId, string $name, string $email, Address $address = null, string $paymentMethod = null): array
+    public function updateCustomer(string $customerId, string $name, string $email, ?Address $address = null, ?string $paymentMethod = null): array
     {
         $path = '/customers/'.$customerId;
         $requestBody = [

--- a/src/Pay/Address.php
+++ b/src/Pay/Address.php
@@ -47,7 +47,7 @@ class Address
      */
     protected ?string $state;
 
-    public function __construct(string $city, string $country, string $line1 = null, string $line2 = null, string $postalCode = null, string $state = null)
+    public function __construct(string $city, string $country, ?string $line1 = null, ?string $line2 = null, ?string $postalCode = null, ?string $state = null)
     {
         $this->city = $city;
         $this->country = $country;

--- a/src/Pay/Exception.php
+++ b/src/Pay/Exception.php
@@ -23,7 +23,7 @@ class Exception extends \Exception
      */
     protected array $metadata = [];
 
-    public function __construct(string $type = Exception::GENERAL_UNKNOWN, string $message = null, int $code = null, array $metadata = [], \Throwable $previous = null)
+    public function __construct(string $type = Exception::GENERAL_UNKNOWN, ?string $message = null, ?int $code = null, array $metadata = [], ?\Throwable $previous = null)
     {
         $this->type = $type;
         $this->code = $code ?? 500;

--- a/src/Pay/Pay.php
+++ b/src/Pay/Pay.php
@@ -81,7 +81,7 @@ class Pay
      * @param  array<mixed>  $additionalParams
      * @return array<mixed>
      */
-    public function purchase(int $amount, string $customerId, string $paymentMethodId = null, array $additionalParams = []): array
+    public function purchase(int $amount, string $customerId, ?string $paymentMethodId = null, array $additionalParams = []): array
     {
         return $this->adapter->purchase($amount, $customerId, $paymentMethodId, $additionalParams);
     }
@@ -98,7 +98,7 @@ class Pay
      * @param  array<mixed>  $additionalParams
      * @return array<mixed>
      */
-    public function authorize(int $amount, string $customerId, string $paymentMethodId = null, array $additionalParams = []): array
+    public function authorize(int $amount, string $customerId, ?string $paymentMethodId = null, array $additionalParams = []): array
     {
         return $this->adapter->authorize($amount, $customerId, $paymentMethodId, $additionalParams);
     }
@@ -178,7 +178,7 @@ class Pay
      * @param  array<mixed>  $additionalParams Additional parameters (optional)
      * @return array<mixed> Result of the update
      */
-    public function updatePayment(string $paymentId, ?string $paymentMethodId = null, ?int $amount = null, string $currency = null, array $additionalParams = []): array
+    public function updatePayment(string $paymentId, ?string $paymentMethodId = null, ?int $amount = null, ?string $currency = null, array $additionalParams = []): array
     {
         return $this->adapter->updatePayment($paymentId, $paymentMethodId, $amount, $currency, $additionalParams);
     }
@@ -218,7 +218,7 @@ class Pay
      * @param  array<mixed>  $address
      * @return array<mixed>
      */
-    public function updatePaymentMethodBillingDetails(string $paymentMethodId, string $type, string $name = null, string $email = null, string $phone = null, array $address = null): array
+    public function updatePaymentMethodBillingDetails(string $paymentMethodId, string $type, ?string $name = null, ?string $email = null, ?string $phone = null, ?array $address = null): array
     {
         return $this->adapter->updatePaymentMethodBillingDetails($paymentMethodId, $name, $email, $phone, $address);
     }
@@ -307,7 +307,7 @@ class Pay
      * @param  Address  $address
      * @return array<mixed>
      */
-    public function updateCustomer(string $customerId, string $name, string $email, Address $address = null, ?string $paymentMethod = null): array
+    public function updateCustomer(string $customerId, string $name, string $email, ?Address $address = null, ?string $paymentMethod = null): array
     {
         return $this->adapter->updateCustomer($customerId, $name, $email, $address, $paymentMethod);
     }


### PR DESCRIPTION
## Summary
- make nullable parameters explicitly nullable to avoid PHP 8.4+ deprecations
- align Adapter/Stripe/Pay signatures with nullable defaults
- update Exception and Address constructors for explicit nullables

## Testing
- php -l on all php files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety across payment processing methods to improve code reliability and consistency.
  * Updated parameter handling for payment operations, refunds, customer management, and billing details to ensure more robust validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->