### PR TITLE
Feat: two-step authorize flow with confirmAuthorization and configurable capture method

### DIFF
--- a/src/Pay/Adapter.php
+++ b/src/Pay/Adapter.php
@@ -81,8 +81,13 @@ abstract class Adapter
     abstract public function purchase(int $amount, string $customerId, ?string $paymentMethodId = null, array $additionalParams = []): array;
 
     /**
-     * Authorize a payment (hold funds without capturing)
-     * Useful for scenarios where you need to ensure payment availability before providing service
+     * Authorize a payment
+     * Creates a payment intent without confirming it. Always call confirmAuthorization() after this.
+     *
+     * Flow with 'automatic' (default): authorize() → confirmAuthorization() → funds captured automatically.
+     * Flow with 'manual': authorize() → confirmAuthorization() → capture() to collect funds.
+     *
+     * You may call cancelAuthorization() before confirmAuthorization() to abort.
      *
      * @param  int  $amount Amount to authorize
      * @param  string  $customerId Customer ID

--- a/src/Pay/Adapter.php
+++ b/src/Pay/Adapter.php
@@ -87,10 +87,11 @@ abstract class Adapter
      * @param  int  $amount Amount to authorize
      * @param  string  $customerId Customer ID
      * @param  string|null  $paymentMethodId Payment method ID (optional)
+     * @param  string  $captureMethod Capture method: 'automatic' (default) or 'manual'
      * @param  array<mixed>  $additionalParams Additional parameters (optional)
      * @return array<mixed> Result of the authorization including authorization ID
      */
-    abstract public function authorize(int $amount, string $customerId, ?string $paymentMethodId = null, array $additionalParams = []): array;
+    abstract public function authorize(int $amount, string $customerId, ?string $paymentMethodId = null, string $captureMethod = 'automatic', array $additionalParams = []): array;
 
     /**
      * Capture a previously authorized payment

--- a/src/Pay/Adapter.php
+++ b/src/Pay/Adapter.php
@@ -104,6 +104,16 @@ abstract class Adapter
     abstract public function capture(string $paymentId, ?int $amount = null, array $additionalParams = []): array;
 
     /**
+     * Confirm a previously created authorization
+     * Sends confirmation to process the authorization (e.g., off_session for saved cards)
+     *
+     * @param  string  $paymentId The payment/authorization ID to confirm
+     * @param  array<mixed>  $additionalParams Additional parameters (optional)
+     * @return array<mixed> Result of the confirmation
+     */
+    abstract public function confirmAuthorization(string $paymentId, array $additionalParams = []): array;
+
+    /**
      * Cancel/void a payment authorization
      * Releases the hold on funds without capturing
      *

--- a/src/Pay/Adapter/Stripe.php
+++ b/src/Pay/Adapter/Stripe.php
@@ -60,8 +60,23 @@ class Stripe extends Adapter
             'customer' => $customerId,
             'payment_method' => $paymentMethodId,
             'capture_method' => 'manual',
+        ];
+
+        $requestBody = array_merge($requestBody, $additionalParams);
+        $result = $this->execute(self::METHOD_POST, $path, $requestBody);
+
+        return $result;
+    }
+
+    /**
+     * Confirm a previously created authorization
+     * Sends off_session: true to confirm without customer interaction (for saved cards)
+     */
+    public function confirmAuthorization(string $paymentId, array $additionalParams = []): array
+    {
+        $path = '/payment_intents/'.$paymentId.'/confirm';
+        $requestBody = [
             'off_session' => 'true',
-            'confirm' => 'true',
         ];
 
         $requestBody = array_merge($requestBody, $additionalParams);

--- a/src/Pay/Adapter/Stripe.php
+++ b/src/Pay/Adapter/Stripe.php
@@ -48,8 +48,13 @@ class Stripe extends Adapter
     }
 
     /**
-     * Authorize a payment (hold funds without capturing)
-     * Creates a payment intent with capture_method set to manual
+     * Authorize a payment
+     * Creates a payment intent without confirming it. Always call confirmAuthorization() after this.
+     *
+     * Flow with 'automatic' (default): authorize() → confirmAuthorization() → funds captured automatically.
+     * Flow with 'manual': authorize() → confirmAuthorization() → capture() to collect funds.
+     *
+     * You may call cancelAuthorization() before confirmAuthorization() to abort.
      */
     public function authorize(int $amount, string $customerId, ?string $paymentMethodId = null, string $captureMethod = 'automatic', array $additionalParams = []): array
     {

--- a/src/Pay/Adapter/Stripe.php
+++ b/src/Pay/Adapter/Stripe.php
@@ -51,7 +51,7 @@ class Stripe extends Adapter
      * Authorize a payment (hold funds without capturing)
      * Creates a payment intent with capture_method set to manual
      */
-    public function authorize(int $amount, string $customerId, ?string $paymentMethodId = null, array $additionalParams = []): array
+    public function authorize(int $amount, string $customerId, ?string $paymentMethodId = null, string $captureMethod = 'automatic', array $additionalParams = []): array
     {
         $path = '/payment_intents';
         $requestBody = [
@@ -59,7 +59,7 @@ class Stripe extends Adapter
             'currency' => $this->currency,
             'customer' => $customerId,
             'payment_method' => $paymentMethodId,
-            'capture_method' => 'manual',
+            'capture_method' => $captureMethod,
         ];
 
         $requestBody = array_merge($requestBody, $additionalParams);

--- a/src/Pay/Pay.php
+++ b/src/Pay/Pay.php
@@ -95,12 +95,13 @@ class Pay
      * @param  int  $amount
      * @param  string  $customerId
      * @param  string|null  $paymentMethodId
+     * @param  string  $captureMethod
      * @param  array<mixed>  $additionalParams
      * @return array<mixed>
      */
-    public function authorize(int $amount, string $customerId, ?string $paymentMethodId = null, array $additionalParams = []): array
+    public function authorize(int $amount, string $customerId, ?string $paymentMethodId = null, string $captureMethod = 'automatic', array $additionalParams = []): array
     {
-        return $this->adapter->authorize($amount, $customerId, $paymentMethodId, $additionalParams);
+        return $this->adapter->authorize($amount, $customerId, $paymentMethodId, $captureMethod, $additionalParams);
     }
 
     /**

--- a/src/Pay/Pay.php
+++ b/src/Pay/Pay.php
@@ -88,9 +88,12 @@ class Pay
 
     /**
      * Authorize
-     * Authorize a payment (hold funds without capturing)
-     * Useful for scenarios where you need to ensure payment availability before providing service
-     * Returns authorization ID on successful authorization
+     * Creates a payment intent without confirming it. Always call confirmAuthorization() after this.
+     *
+     * Flow with 'automatic' (default): authorize() → confirmAuthorization() → funds captured automatically.
+     * Flow with 'manual': authorize() → confirmAuthorization() → capture() to collect funds.
+     *
+     * You may call cancelAuthorization() before confirmAuthorization() to abort.
      *
      * @param  int  $amount
      * @param  string  $customerId

--- a/src/Pay/Pay.php
+++ b/src/Pay/Pay.php
@@ -104,6 +104,19 @@ class Pay
     }
 
     /**
+     * Confirm Authorization
+     * Confirm a previously created authorization
+     *
+     * @param  string  $paymentId
+     * @param  array<mixed>  $additionalParams
+     * @return array<mixed>
+     */
+    public function confirmAuthorization(string $paymentId, array $additionalParams = []): array
+    {
+        return $this->adapter->confirmAuthorization($paymentId, $additionalParams);
+    }
+
+    /**
      * Capture
      * Capture a previously authorized payment
      * Completes the payment and transfers funds from customer

--- a/tests/Pay/Adapter/StripeTest.php
+++ b/tests/Pay/Adapter/StripeTest.php
@@ -631,16 +631,22 @@ class StripeTest extends TestCase
         $customerId = $data['customerId'];
         $paymentMethodId = $data['paymentMethodId'];
 
-        // Authorize payment - hold funds without capturing
+        // Authorize payment - creates intent without confirming
         $authorization = $this->stripe->authorize(10000, $customerId, $paymentMethodId);
 
         $this->assertNotEmpty($authorization['id']);
         $this->assertEquals('payment_intent', $authorization['object']);
         $this->assertEquals(10000, $authorization['amount']);
-        $this->assertEquals('requires_capture', $authorization['status']);
+        $this->assertEquals('requires_confirmation', $authorization['status']);
         $this->assertEquals('manual', $authorization['capture_method']);
 
-        $data['authorizationId'] = $authorization['id'];
+        // Confirm the authorization
+        $confirmed = $this->stripe->confirmAuthorization($authorization['id']);
+
+        $this->assertEquals($authorization['id'], $confirmed['id']);
+        $this->assertEquals('requires_capture', $confirmed['status']);
+
+        $data['authorizationId'] = $confirmed['id'];
 
         return $data;
     }
@@ -685,7 +691,11 @@ class StripeTest extends TestCase
         $authorization = $this->stripe->authorize(15000, $customerId, $paymentMethodId);
         $authorizationId = $authorization['id'];
 
-        $this->assertEquals('requires_capture', $authorization['status']);
+        $this->assertEquals('requires_confirmation', $authorization['status']);
+
+        // Confirm the authorization
+        $confirmed = $this->stripe->confirmAuthorization($authorizationId);
+        $this->assertEquals('requires_capture', $confirmed['status']);
 
         // Capture partial amount (only 10000 of 15000)
         $captured = $this->stripe->capture($authorizationId, 10000);
@@ -713,9 +723,9 @@ class StripeTest extends TestCase
         $authorization = $this->stripe->authorize(8000, $customerId, $paymentMethodId);
         $authorizationId = $authorization['id'];
 
-        $this->assertEquals('requires_capture', $authorization['status']);
+        $this->assertEquals('requires_confirmation', $authorization['status']);
 
-        // Cancel the authorization - release the hold
+        // Cancel the authorization - release the hold (can cancel before confirming)
         $cancelled = $this->stripe->cancelAuthorization($authorizationId);
 
         $this->assertNotEmpty($cancelled['id']);
@@ -753,7 +763,7 @@ class StripeTest extends TestCase
         );
 
         $this->assertNotEmpty($authorization['id']);
-        $this->assertEquals('requires_capture', $authorization['status']);
+        $this->assertEquals('requires_confirmation', $authorization['status']);
         $this->assertEquals('example.com', $authorization['metadata']['domain']);
         $this->assertEquals('ORD-12345', $authorization['metadata']['order_id']);
         $this->assertEquals('domain_registration', $authorization['metadata']['resource_type']);

--- a/tests/Pay/Adapter/StripeTest.php
+++ b/tests/Pay/Adapter/StripeTest.php
@@ -632,7 +632,7 @@ class StripeTest extends TestCase
         $paymentMethodId = $data['paymentMethodId'];
 
         // Authorize payment - creates intent without confirming
-        $authorization = $this->stripe->authorize(10000, $customerId, $paymentMethodId);
+        $authorization = $this->stripe->authorize(10000, $customerId, $paymentMethodId, 'manual');
 
         $this->assertNotEmpty($authorization['id']);
         $this->assertEquals('payment_intent', $authorization['object']);
@@ -688,7 +688,7 @@ class StripeTest extends TestCase
         $paymentMethodId = $data['paymentMethodId'];
 
         // Authorize payment
-        $authorization = $this->stripe->authorize(15000, $customerId, $paymentMethodId);
+        $authorization = $this->stripe->authorize(15000, $customerId, $paymentMethodId, 'manual');
         $authorizationId = $authorization['id'];
 
         $this->assertEquals('requires_confirmation', $authorization['status']);
@@ -720,7 +720,7 @@ class StripeTest extends TestCase
         $paymentMethodId = $data['paymentMethodId'];
 
         // Authorize payment
-        $authorization = $this->stripe->authorize(8000, $customerId, $paymentMethodId);
+        $authorization = $this->stripe->authorize(8000, $customerId, $paymentMethodId, 'manual');
         $authorizationId = $authorization['id'];
 
         $this->assertEquals('requires_confirmation', $authorization['status']);
@@ -752,6 +752,7 @@ class StripeTest extends TestCase
             12000,
             $customerId,
             $paymentMethodId,
+            'manual',
             [
                 'metadata' => [
                     'domain' => 'example.com',


### PR DESCRIPTION
## Summary
- Splits `authorize()` into a two-step flow: `authorize()` creates the payment intent without confirming, then `confirmAuthorization()` confirms it
- Adds `$captureMethod` parameter to `authorize()` (default: `'automatic'`), replacing the hardcoded `'manual'`
- Adds `confirmAuthorization()` method across `Adapter`, `Stripe`, and `Pay`

### Authorization flow
- **Automatic capture:** `authorize()` → `confirmAuthorization()` → funds captured automatically
- **Manual capture:** `authorize(..., 'manual')` → `confirmAuthorization()` → `capture()` to collect funds
- Call `cancelAuthorization()` before `confirmAuthorization()` to abort

## Test plan
- [ ] Verify `authorize()` returns `requires_confirmation` status
- [ ] Verify `confirmAuthorization()` transitions to `requires_capture` (manual) or `succeeded` (automatic)
- [ ] Verify `cancelAuthorization()` works on unconfirmed authorizations
- [ ] Verify partial capture still works after confirm
- [ ] Verify metadata pass-through on authorize