### PR TITLE
Fix PHP 8.5 curl_close() deprecation

### DIFF
--- a/src/Pay/Adapter.php
+++ b/src/Pay/Adapter.php
@@ -397,8 +397,6 @@ abstract class Adapter
             $this->handleError($responseStatus, $responseBody);
         }
 
-        curl_close($ch);
-
         return $responseBody;
     }
 


### PR DESCRIPTION
## Summary
- Remove the no-op `curl_close($ch)` call in `Pay\Adapter` that triggers a `Deprecated` notice on PHP 8.5.

## Why
`curl_close()` has been a no-op since PHP 8.0 and is now formally deprecated in 8.5. The curl handle is freed when the variable goes out of scope.

## Test plan
- [x] `composer lint` (Pint) — pass
- [ ] `composer check` (PHPStan) — pre-existing failure on `main` unrelated to this change (pinned `phpstan/phpstan: 1.9.x-dev` is incompatible with PHP 8.4's stricter `ReflectionClassConstant::IS_PUBLIC` type signature). Repo CI does not run PHPStan.